### PR TITLE
Fix issue where Slack returns upload_error when using webAPI.uploadFile

### DIFF
--- a/Sources/NetworkInterface.swift
+++ b/Sources/NetworkInterface.swift
@@ -134,12 +134,14 @@ public struct NetworkInterface {
         let boundaryEnd = "--\(boundaryConstant)--\r\n"
         let contentDispositionString = "Content-Disposition: form-data; name=\"file\"; filename=\"\(filename)\"\r\n"
         let contentTypeString = "Content-Type: \(filetype)\r\n\r\n"
+        let dataEnd = "\r\n"
 
         guard
             let boundaryStartData = boundaryStart.data(using: .utf8),
             let dispositionData = contentDispositionString.data(using: .utf8),
             let contentTypeData = contentTypeString.data(using: .utf8),
-            let boundaryEndData = boundaryEnd.data(using: .utf8)
+            let boundaryEndData = boundaryEnd.data(using: .utf8),
+            let dataEndData = dataEnd.data(using: .utf8)
         else {
             errorClosure(SlackError.clientNetworkError)
             return
@@ -150,6 +152,7 @@ public struct NetworkInterface {
         requestBodyData.append(contentsOf: dispositionData)
         requestBodyData.append(contentsOf: contentTypeData)
         requestBodyData.append(contentsOf: data)
+        requestBodyData.append(contentsOf: dataEndData)
         requestBodyData.append(contentsOf: boundaryEndData)
 
         request.setValue(contentType, forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
With the latest version of SKWebAPI, I'm unable to successfully upload a file to Slack. The error being returned by Slack is upload_error.

I compared the sources for SKWebAPI against one of the earlier versions which worked for me and found that this bit of code in NetworkInterface.swift was left out. After adding this, uploads work again without an errors.