### PR TITLE
Provide the user/team IDs when handling authTest success

### DIFF
--- a/Sources/WebAPI.swift
+++ b/Sources/WebAPI.swift
@@ -35,6 +35,7 @@ public final class WebAPI {
     public typealias HistoryClosure = (_ history: History) -> Void
     public typealias FileClosure = (_ file: File) -> Void
     public typealias ItemsClosure = (_ items: [Item]?) -> Void
+    public typealias AuthTestClosure = (_ user: String, _ team: String) -> Void
 
     public enum InfoType: String {
         case purpose, topic
@@ -115,9 +116,9 @@ extension WebAPI {
 
 // MARK: - Auth
 extension WebAPI {
-    public func authenticationTest(success: SuccessClosure?, failure: FailureClosure?) {
-        networkInterface.request(.authTest, parameters: ["token": token], successClosure: { _ in
-            success?(true)
+    public func authenticationTest(success: AuthTestClosure?, failure: FailureClosure?) {
+        networkInterface.request(.authTest, parameters: ["token": token], successClosure: { (response) in
+            success?(response["user_id"] as! String, response["team_id"] as! String)
         }) {(error) in
             failure?(error)
         }

--- a/Sources/WebAPI.swift
+++ b/Sources/WebAPI.swift
@@ -35,7 +35,7 @@ public final class WebAPI {
     public typealias HistoryClosure = (_ history: History) -> Void
     public typealias FileClosure = (_ file: File) -> Void
     public typealias ItemsClosure = (_ items: [Item]?) -> Void
-    public typealias AuthTestClosure = (_ user: String, _ team: String) -> Void
+    public typealias AuthTestClosure = (_ user: String?, _ team: String?) -> Void
 
     public enum InfoType: String {
         case purpose, topic
@@ -118,7 +118,7 @@ extension WebAPI {
 extension WebAPI {
     public func authenticationTest(success: AuthTestClosure?, failure: FailureClosure?) {
         networkInterface.request(.authTest, parameters: ["token": token], successClosure: { (response) in
-            success?(response["user_id"] as! String, response["team_id"] as! String)
+            success?(response["user_id"] as? String, response["team_id"] as? String)
         }) {(error) in
             failure?(error)
         }


### PR DESCRIPTION
Slack's API documentation seems to indicate that the best way to figure out "who am I" is to get the user and team ID from the JSON returned by the authentication test command. 

This PR changes from using the SuccessClosure to a new AuthTestClosure that provides the user and team IDs to the caller. 